### PR TITLE
Set labs as WKDIR

### DIFF
--- a/template/pydata/Dockerfile
+++ b/template/pydata/Dockerfile
@@ -2,13 +2,13 @@ FROM python:3-slim
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl \
-        build-essential \
+    curl \
+    build-essential \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.15/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog 
 
-WORKDIR /root/
+WORKDIR /labs/
 
 COPY index.py           .
 COPY requirements.txt   .
@@ -18,11 +18,11 @@ COPY function           function
 
 RUN touch ./function/__init__.py
 
-WORKDIR /root/function/
+WORKDIR /labs/function/
 COPY function/requirements.txt	.
 RUN pip install -r requirements.txt
 
-WORKDIR /root/
+WORKDIR /labs/
 
 ENV fprocess="python3 index.py"
 


### PR DESCRIPTION
These templates are used for Labs, where the root
working directory is `/labs`. The templates should
use this convention as well.