### PR TITLE
Use python:3.6-slim

### DIFF
--- a/template/pydata/Dockerfile
+++ b/template/pydata/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.6-slim
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.6-slim
 
 RUN pip install flask
 RUN touch /tmp/.lock


### PR DESCRIPTION
In our Dockerfiles that inherit from `python`, use the
`3.6-slim` tag instead of `3-slim`. This fixes the Python version
so that we don't introduce any breaking Python 3.7 changes.